### PR TITLE
Add error handling for export

### DIFF
--- a/binary-waterfall.py
+++ b/binary-waterfall.py
@@ -643,7 +643,7 @@ class QtBarLoggerMoviepy(ProgressBarLogger):
     def callback(self, **changes):
         if "message" in changes:
             message = changes["message"].strip("Moviepy - ")
-            
+
             if "Building video" in message:
                 self.progress_dialog.setLabelText("(1/3) Building video...")
             elif "Writing audio" in message:
@@ -658,7 +658,7 @@ class QtBarLoggerMoviepy(ProgressBarLogger):
                 self.progress_dialog.setLabelText("Video is ready!")
             else:
                 self.progress_dialog.setLabelText(message)
-    
+
     def bars_callback(self, bar, attr, value, old_value=None):
         percent = (value / self.bars[bar]["total"]) * 100
         self.set_progress(round(percent))
@@ -2369,29 +2369,38 @@ class MyQMainWindow(QMainWindow):
                 else:
                     add_watermark = True
 
-                self.renderer.export_video(
-                    filename=filename,
-                    size=(settings["width"], settings["height"]),
-                    fps=settings["fps"],
-                    keep_aspect=settings["keep_aspect"],
-                    watermark=add_watermark,
-                    progress_dialog=progress_popup
-                )
-
-                if progress_popup.wasCanceled():
-                    choice = QMessageBox.warning(
+                try:
+                    self.renderer.export_video(
+                        filename=filename,
+                        size=(settings["width"], settings["height"]),
+                        fps=settings["fps"],
+                        keep_aspect=settings["keep_aspect"],
+                        watermark=add_watermark,
+                        progress_dialog=progress_popup
+                    )
+                except Exception as e:
+                    progress_popup.cancel()
+                    choice = QMessageBox.critical(
                         self,
-                        "Export Aborted",
-                        f"Export video aborted!",
+                        "Unable to Export Video",
+                        str(e),
                         QMessageBox.Ok
                     )
                 else:
-                    choice = QMessageBox.information(
-                        self,
-                        "Export Complete",
-                        f"Export video successful!",
-                        QMessageBox.Ok
-                    )
+                    if progress_popup.wasCanceled():
+                        choice = QMessageBox.warning(
+                            self,
+                            "Export Aborted",
+                            f"Export video aborted!",
+                            QMessageBox.Ok
+                        )
+                    else:
+                        choice = QMessageBox.information(
+                            self,
+                            "Export Complete",
+                            f"Export video successful!",
+                            QMessageBox.Ok
+                        )
 
     def hotkeys_clicked(self):
         popup = HotkeysInfo(parent=self)
@@ -2407,7 +2416,7 @@ class MyQMainWindow(QMainWindow):
         popup = About(parent=self)
 
         result = popup.exec()
-    
+
     # TODO: Add video export settings (encoder, bitrate, quality, stuff like that)
     # TODO: Add unit testing (https://realpython.com/python-testing/)
     # TODO: Add documentation (https://realpython.com/python-doctest/)

--- a/binary-waterfall.py
+++ b/binary-waterfall.py
@@ -2205,19 +2205,27 @@ class MyQMainWindow(QMainWindow):
             if filename != "":
                 file_path, file_title = os.path.split(filename)
                 self.last_save_location = file_path
-                self.renderer.export_frame(
-                    ms=self.player.get_position(),
-                    filename=filename,
-                    size=(settings["width"], settings["height"]),
-                    keep_aspect=settings["keep_aspect"]
-                )
-
-                choice = QMessageBox.information(
-                    self,
-                    "Export Complete",
-                    f"Export image successful!",
-                    QMessageBox.Ok
-                )
+                try:
+                    self.renderer.export_frame(
+                        ms=self.player.get_position(),
+                        filename=filename,
+                        size=(settings["width"], settings["height"]),
+                        keep_aspect=settings["keep_aspect"]
+                    )
+                except Exception as e:
+                    choice = QMessageBox.critical(
+                        self,
+                        "Export Error",
+                        f"An error occurred while exporting frame: {str(e)}",
+                        QMessageBox.Ok
+                    )
+                else:
+                    choice = QMessageBox.information(
+                        self,
+                        "Export Complete",
+                        f"Export image successful!",
+                        QMessageBox.Ok
+                    )
 
     def export_audio_clicked(self):
         if self.bw.audio_filename == None:
@@ -2239,16 +2247,24 @@ class MyQMainWindow(QMainWindow):
         if filename != "":
             file_path, file_title = os.path.split(filename)
             self.last_save_location = file_path
-            self.renderer.export_audio(
-                filename=filename
-            )
-
-            choice = QMessageBox.information(
-                self,
-                "Export Complete",
-                f"Export audio successful!",
-                QMessageBox.Ok
-            )
+            try:
+                self.renderer.export_audio(
+                    filename=filename
+                )
+            except Exception as e:
+                choice = QMessageBox.critical(
+                    self,
+                    "Export Error",
+                    f"An error occurred while exporting audio: {str(e)}",
+                    QMessageBox.Ok
+                )
+            else:
+                choice = QMessageBox.information(
+                    self,
+                    "Export Complete",
+                    f"Export audio successful!",
+                    QMessageBox.Ok
+                )
 
     def export_sequence_clicked(self):
         if self.bw.audio_filename == None:
@@ -2289,30 +2305,39 @@ class MyQMainWindow(QMainWindow):
                 progress_popup.setWindowTitle("Exporting Images...")
                 progress_popup.setFixedSize(300, 100)
 
-                self.renderer.export_sequence(
-                    directory=file_dir,
-                    size=(settings["width"], settings["height"]),
-                    fps=settings["fps"],
-                    keep_aspect=settings["keep_aspect"],
-                    format=settings["format"],
-                    progress_dialog=progress_popup
-                )
-
-                if progress_popup.wasCanceled():
-                    # shutil.rmtree(file_dir) # Dangerous! May delete user data
-                    choice = QMessageBox.warning(
+                try:
+                    self.renderer.export_sequence(
+                        directory=file_dir,
+                        size=(settings["width"], settings["height"]),
+                        fps=settings["fps"],
+                        keep_aspect=settings["keep_aspect"],
+                        format=settings["format"],
+                        progress_dialog=progress_popup
+                    )
+                except Exception as e:
+                    progress_popup.cancel()
+                    choice = QMessageBox.critical(
                         self,
-                        "Export Aborted",
-                        f"Export image sequence aborted!",
+                        "Export Error",
+                        f"An error occurred while exporting image sequence: {str(e)}",
                         QMessageBox.Ok
                     )
                 else:
-                    choice = QMessageBox.information(
-                        self,
-                        "Export Complete",
-                        f"Export image sequence successful!",
-                        QMessageBox.Ok
-                    )
+                    if progress_popup.wasCanceled():
+                        # shutil.rmtree(file_dir) # Dangerous! May delete user data
+                        choice = QMessageBox.warning(
+                            self,
+                            "Export Aborted",
+                            f"Export image sequence aborted!",
+                            QMessageBox.Ok
+                        )
+                    else:
+                        choice = QMessageBox.information(
+                            self,
+                            "Export Complete",
+                            f"Export image sequence successful!",
+                            QMessageBox.Ok
+                        )
 
     def export_video_clicked(self):
         if self.bw.audio_filename == None:
@@ -2382,8 +2407,8 @@ class MyQMainWindow(QMainWindow):
                     progress_popup.cancel()
                     choice = QMessageBox.critical(
                         self,
-                        "Unable to Export Video",
-                        str(e),
+                        "Export Error",
+                        f"An error occurred while exporting video: {str(e)}",
                         QMessageBox.Ok
                     )
                 else:


### PR DESCRIPTION
Have the main window catch any errors thrown by the renderer and display them as a critical message box:

![Example error message box](https://github.com/nimaid/binary-waterfall/assets/34503494/a3027d23-1659-43a1-b1a5-a90792c9e413)

Previously, any errors that occurred during export (e.g. out of storage) would go uncaught and crash the entire program, potentially leaving a huge mess behind as it doesn't have the chance to cleanup the files.

## How to test

Create some condition that might lead to an error, or intentionally throw one by placing something like `raise Exception("Example error thrown in export_video()")` in the `Renderer` export methods.