### PR TITLE
Added a requirements.txt for legacy installers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,8 +9,9 @@ dependencies:
   - pip:
     - pyinstaller
     - pyinstaller-versionfile
-    - PyQt5
-    - pydub
-    - Pillow
-    - moviepy
-    - proglog
+    - pyyaml==6.0.3
+    - PyQt5==5.15.11
+    - pydub==0.25.1
+    - Pillow==11.3.0
+    - moviepy==2.2.1
+    - proglog==0.1.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,8 @@ name = "binary-waterfall"
 version = "3.7.0"
 readme = "README_pypi.md"
 description = "A Raw Data Media Player"
-license= {file = "LICENSE"}
-authors = [
-    {name = "Ella Jameson", email = "ellagjameson@gmail.com"}
-]
+license = { file = "LICENSE" }
+authors = [{ name = "Ella Jameson", email = "ellagjameson@gmail.com" }]
 classifiers = [
     "Topic :: Multimedia",
     "Topic :: Multimedia :: Graphics",
@@ -21,15 +19,15 @@ classifiers = [
     "Topic :: Multimedia :: Sound/Audio :: Players",
     "Topic :: Multimedia :: Video",
     "Topic :: Multimedia :: Video :: Conversion",
-    "Topic :: Multimedia :: Video :: Display"
+    "Topic :: Multimedia :: Video :: Display",
 ]
 dependencies = [
-    "pyyaml",
-    "Pillow",
-    "PyQt5",
-    "pydub",
-    "moviepy",
-    "proglog"
+    "pyyaml==6.0.3",
+    "Pillow==11.3.0",
+    "PyQt5==5.15.11",
+    "pydub==0.25.1",
+    "moviepy==2.2.1",
+    "proglog==0.1.12",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+# All the dependencies are now tracked in the pyproject.toml, this file is provided for legacy reasons.
+-e .

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,0 +1,4 @@
+import binary_waterfall
+
+if __name__ == "__main__":
+    binary_waterfall.run()

--- a/src/binary_waterfall/dialogs.py
+++ b/src/binary_waterfall/dialogs.py
@@ -1010,7 +1010,7 @@ class About(QDialog):
         self.icon_label.setFixedSize(self.icon_size, self.icon_size)
 
         self.about_text = QLabel(
-            f"{constants.TITLE} v{constants.VERSION}\nby {constants.COPYRIGHT}\n© Copyright 2023\n\n"
+            f"{constants.TITLE} v{constants.VERSION}\nby {constants.COPYRIGHT}\n© Copyright 2026\n\n"
             f"{constants.DESCRIPTION}\n\n"
             f"Project Home Page:\n{constants.PROJECT_URL}\n\n"
             f"Donate:\n{constants.DONATE_URL}")

--- a/src/binary_waterfall/outputs.py
+++ b/src/binary_waterfall/outputs.py
@@ -4,7 +4,8 @@ import math
 import time
 import tempfile
 import pydub
-from moviepy.editor import ImageSequenceClip, AudioFileClip
+# moviepy 2.x exposes core classes at package root; import directly for compatibility
+from moviepy import ImageSequenceClip, AudioFileClip
 from PIL import Image
 from PyQt5.QtCore import QUrl
 from PyQt5.QtMultimedia import QMediaPlayer, QMediaContent
@@ -294,7 +295,8 @@ class Renderer:
             resized = source
         else:
             if keep_aspect:
-                output_size = helpers.get_size_for_fit_frame(content_size=source.size, frame_size=size)["size"]
+                output_size = helpers.get_size_for_fit_frame(
+                    content_size=source.size, frame_size=size)["size"]
             else:
                 output_size = size
 
@@ -320,10 +322,12 @@ class Renderer:
             shutil.copy(self.bw.audio_filename, filename)
         elif filename_ext == constants.AudioFormatCode.MP3.value:
             # Use Pydub to export MP3
-            pydub.AudioSegment.from_wav(self.bw.audio_filename).export(filename, format="mp3")
+            pydub.AudioSegment.from_wav(
+                self.bw.audio_filename).export(filename, format="mp3")
         elif filename_ext == constants.AudioFormatCode.FLAC.value:
             # Use Pydub to export FLAC
-            pydub.AudioSegment.from_wav(self.bw.audio_filename).export(filename, format="flac")
+            pydub.AudioSegment.from_wav(
+                self.bw.audio_filename).export(filename, format="flac")
 
     def get_frame_count(self, fps):
         audio_duration = self.bw.get_audio_length() / 1000
@@ -350,7 +354,8 @@ class Renderer:
 
         for frame in range(frame_count):
             frame_number = str(frame).rjust(frame_number_digits, "0")
-            frame_filename = os.path.join(directory, f"{frame_number}{image_format.value}")
+            frame_filename = os.path.join(
+                directory, f"{frame_number}{image_format.value}")
             frame_ms = round((frame / fps) * 1000)
 
             if progress_dialog is not None:
@@ -409,14 +414,16 @@ class Renderer:
             if progress_dialog.wasCanceled():
                 shutil.rmtree(temp_dir)
                 return
-            progress_dialog.setLabelText("Splicing final video file... (program may lag)")
+            progress_dialog.setLabelText(
+                "Splicing final video file... (program may lag)")
 
         # Export audio
         self.export_audio(audio_file)
 
         # Prepare the custom logger to update the progress box
         if progress_dialog is not None:
-            custom_logger = helpers.QtBarLoggerMoviepy(progress_dialog=progress_dialog)
+            custom_logger = helpers.QtBarLoggerMoviepy(
+                progress_dialog=progress_dialog)
         else:
             custom_logger = "bar"
 

--- a/src/binary_waterfall/version.yml
+++ b/src/binary_waterfall/version.yml
@@ -1,4 +1,4 @@
-Version: 3.7.0
+Version: 3.8.0
 CompanyName: Ella Jameson (nimaid)
 FileDescription: A Raw Data Media Player
 InternalName: Binary Waterfall


### PR DESCRIPTION
Important (summary of the changes)
Fixed the import error that occured for moviepy due to drastic updates of the module from when the import lines where written and the current module is being downloaded
Froze the versions of the modules so that the project remains stable and does not break due to a module update
Add a requirements.txt that calls the pyproject.toml so that people who are used to running the command pip install -r ./requirments.txt are not lost.



Copilot explanation
This pull request focuses on dependency management and compatibility updates, particularly for the `moviepy` library, as well as minor code formatting improvements in `outputs.py`. The most important changes are as follows:

**Dependency and Compatibility Updates:**

* Updated all core dependencies in `pyproject.toml` to use specific version pins, ensuring reproducible builds and avoiding unexpected breakages from upstream updates.
* Changed the import of `ImageSequenceClip` and `AudioFileClip` in `outputs.py` to import directly from the `moviepy` package root, ensuring compatibility with moviepy 2.x.

**Code Formatting and Readability:**

* Reformatted several function calls in `outputs.py` to use multi-line style for improved readability, especially where arguments are long or complex. [[1]](diffhunk://#diff-2c7551e73b6a47b5379507603c270a32926a846cf42a91c771589359b35f3701L297-R299) [[2]](diffhunk://#diff-2c7551e73b6a47b5379507603c270a32926a846cf42a91c771589359b35f3701L323-R330) [[3]](diffhunk://#diff-2c7551e73b6a47b5379507603c270a32926a846cf42a91c771589359b35f3701L353-R358) [[4]](diffhunk://#diff-2c7551e73b6a47b5379507603c270a32926a846cf42a91c771589359b35f3701L412-R426)
* Minor formatting adjustment to the `authors` field in `pyproject.toml` for consistency.