### PR TITLE
Add Python 3.13 audioop fallback dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "Pillow",
     "PyQt5",
     "pydub",
+    "audioop-lts; python_version >= '3.13'",
     "moviepy",
     "proglog"
 ]


### PR DESCRIPTION
## Summary
- add udioop-lts as a Python 3.13+ dependency
- keep older Python versions on the stdlib udioop module

## Validation
- Not run locally

Fixes #39