### PR TITLE
Add python -m entrypoint

### DIFF
--- a/README_pypi.md
+++ b/README_pypi.md
@@ -6,7 +6,7 @@
 <p align="center"><a href="https://www.youtube.com/watch?v=NFe0aGO9-TE">Inspired by this video.</a></p>
 
 ## Command Line Usage
-After installing the module, run `binary-waterfall`.
+After installing the module, run `binary-waterfall` or `python -m binary_waterfall`.
 
 ## Attribution
 If you use this program to make a video or other project, you must provide attribution. Attribution is required regardless of whether your project is for-profit or not. Please reproduce the following attribution statement in full in your video description or otherwise include it in the references for your project:

--- a/src/binary_waterfall/__main__.py
+++ b/src/binary_waterfall/__main__.py
@@ -1,0 +1,5 @@
+from . import run
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
## Summary
- add `src/binary_waterfall/__main__.py` so `python -m binary_waterfall` starts the same `run()` entrypoint as the console script
- document the module launch command next to `binary-waterfall`

Fixes #28

## Validation
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- Not run locally