### PR TITLE
Support MoviePy 2 imports

### DIFF
--- a/src/binary_waterfall/outputs.py
+++ b/src/binary_waterfall/outputs.py
@@ -4,7 +4,12 @@ import math
 import time
 import tempfile
 import pydub
-from moviepy.editor import ImageSequenceClip, AudioFileClip
+try:
+    from moviepy.editor import AudioFileClip, ImageSequenceClip
+except ModuleNotFoundError as exc:
+    if exc.name != "moviepy.editor":
+        raise
+    from moviepy import AudioFileClip, ImageSequenceClip
 from PIL import Image
 from PyQt5.QtCore import QUrl
 from PyQt5.QtMultimedia import QMediaPlayer, QMediaContent


### PR DESCRIPTION
Summary:
- keep the MoviePy 1.x `moviepy.editor` import path when it exists
- fall back to MoviePy 2.x top-level imports when only `moviepy.editor` is missing
- re-raise other missing-module errors instead of hiding dependency problems

Validation:
- `git diff --check`
- `git diff --cached --check`
- `git show --check --stat --oneline HEAD`
- Not run locally.

Closes #37